### PR TITLE
fix-wxpay-price-bug

### DIFF
--- a/src/WxPay.php
+++ b/src/WxPay.php
@@ -11,6 +11,10 @@ use wycto\pay\wxpay\WxPayApi;
 use wycto\pay\wxpay\JsApiPay;
 class WxPay extends PayAbstract
 {
+    // 人民币元转分比例
+    const RMB_YUAN_FEN_RATE = 100;
+
+
     // 全局唯一实例
     private static $_app = null;
 
@@ -39,7 +43,11 @@ class WxPay extends PayAbstract
         $input->SetBody($paran['body']);
         $input->SetAttach("attach");
         $input->SetOut_trade_no($paran['out_trade_no']);
-        $input->SetTotal_fee($paran['total_fee']*100);
+        // 浮点型计算可能出现丢失精度问题，如 19.9 * 100
+        // @todo: 安装相关函数拓展后，推荐使用以下方式对人民币价格单位进行转换
+        // $total_fee = (int)bcmul($paran['total_fee'], self::RMB_YUAN_FEN_RATE),
+        $total_fee = (string)($paran['total_fee'] * self::RMB_YUAN_FEN_RATE);
+        $input->SetTotal_fee($total_fee);
         $input->SetTime_start(date("YmdHis"));
         $input->SetTime_expire(date("YmdHis", time() + 600));
         $input->SetGoods_tag("test");


### PR DESCRIPTION
- BUG：微信支付时需将人民币价格单位转为“分”，当传入价格为浮点数时，计算结果可能丢失精度，eg：
    ```PHP
    return 19.9 * 100 // 接口将返回 1989.9999999999
    ```